### PR TITLE
Acts as party

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    petri_flow (0.2.2)
+    petri_flow (0.2.3)
       bootstrap (~> 4.4.1)
       bootstrap4-kaminari-views
       jquery-rails

--- a/acts_as_party.md
+++ b/acts_as_party.md
@@ -1,0 +1,26 @@
+## Usage
+
+
+for normal org model, for example group or role etc.
+
+```ruby
+module Wf
+  class Group < ApplicationRecord
+    has_many :users 
+    include Wf::ActsAsParty
+    acts_as_party(user: false, party_name: :name)
+  end
+end
+```
+
+for user model:
+
+```ruby
+module Wf
+  class User < ApplicationRecord
+    belongs_to :group, optional: true
+    include Wf::ActsAsParty
+    acts_as_party(user: true, party_name: :name)
+  end
+end
+```

--- a/app/models/wf/acts_as_party.rb
+++ b/app/models/wf/acts_as_party.rb
@@ -1,0 +1,21 @@
+require 'active_support/concern'
+
+module Wf
+  module ActsAsParty
+   extend ActiveSupport::Concern
+ 
+    included do
+      has_one :party, as: :partable
+    end
+ 
+    module ClassMethods
+      def acts_as_party(options = {user: false, party_name: :name})
+        cattr_accessor :yaffle_text_field
+        self.has_many :users, foreign_key: :id if options[:user]
+        self.after_create do
+          create_party(party_name: options[:party_name])
+        end
+      end
+    end
+  end
+end

--- a/app/models/wf/group.rb
+++ b/app/models/wf/group.rb
@@ -13,9 +13,7 @@
 module Wf
   class Group < ApplicationRecord
     has_many :users
-    has_one :party, as: :partable
-    after_create do
-      create_party(party_name: name)
-    end
+    include Wf::ActsAsParty
+    acts_as_party(user: false, party_name: :name)
   end
 end

--- a/app/models/wf/user.rb
+++ b/app/models/wf/user.rb
@@ -14,13 +14,7 @@
 module Wf
   class User < ApplicationRecord
     belongs_to :group, optional: true
-    has_one :party, as: :partable
-
-    # NOTICE: group or user or role all has_many users
-    has_many :users, foreign_key: :id
-
-    after_create do
-      create_party(party_name: name)
-    end
+    include Wf::ActsAsParty
+    acts_as_party(user: true, party_name: :name)
   end
 end

--- a/lib/wf/version.rb
+++ b/lib/wf/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wf
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
## Usage

for normal org model, for example group or role etc.

```ruby
module Wf
  class Group < ApplicationRecord
    has_many :users 
    include Wf::ActsAsParty
    acts_as_party(user: false, party_name: :name)
  end
end
```

for user model:

```ruby
module Wf
  class User < ApplicationRecord
    belongs_to :group, optional: true
    include Wf::ActsAsParty
    acts_as_party(user: true, party_name: :name)
  end
end
```