### PR TITLE
add assignment callback logic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    petri_flow (0.2.3)
+    petri_flow (0.2.4)
       bootstrap (~> 4.4.1)
       bootstrap4-kaminari-views
       jquery-rails

--- a/app/models/wf/acts_as_party.rb
+++ b/app/models/wf/acts_as_party.rb
@@ -1,18 +1,20 @@
-require 'active_support/concern'
+# frozen_string_literal: true
+
+require "active_support/concern"
 
 module Wf
   module ActsAsParty
-   extend ActiveSupport::Concern
- 
+    extend ActiveSupport::Concern
+
     included do
       has_one :party, as: :partable
     end
- 
+
     module ClassMethods
-      def acts_as_party(options = {user: false, party_name: :name})
+      def acts_as_party(options = { user: false, party_name: :name })
         cattr_accessor :yaffle_text_field
-        self.has_many :users, foreign_key: :id if options[:user]
-        self.after_create do
+        has_many :users, foreign_key: :id if options[:user]
+        after_create do
           create_party(party_name: options[:party_name])
         end
       end

--- a/app/models/wf/callbacks/assignment_default.rb
+++ b/app/models/wf/callbacks/assignment_default.rb
@@ -4,7 +4,7 @@ module Wf::Callbacks
   class AssignmentDefault < ApplicationJob
     queue_as :default
 
-    def perform(workitem_id)
+    def perform(_workitem_id)
       # return Party array.
       []
     end

--- a/app/models/wf/callbacks/assignment_default.rb
+++ b/app/models/wf/callbacks/assignment_default.rb
@@ -4,9 +4,9 @@ module Wf::Callbacks
   class AssignmentDefault < ApplicationJob
     queue_as :default
 
-    def perform(*guests)
-      $stdout.puts(guests.inspect)
-      [] # return blank default
+    def perform(workitem_id)
+      # return Party array.
+      []
     end
   end
 end

--- a/app/models/wf/case_command/set_workitem_assignments.rb
+++ b/app/models/wf/case_command/set_workitem_assignments.rb
@@ -17,9 +17,11 @@ module Wf::CaseCommand
         end
 
         unless has_case_ass
-          callback_values = workitem.transition.assignment_callback.constantize.new(workitem.id).perform
-          if callback_values.present?
-            # TODO: do assignment for callback.
+          callback_parties = workitem.transition.assignment_callback.constantize.new.perform(workitem.id)
+          if callback_parties.present?
+            callback_parties.each do |party|
+               AddWorkitemAssignment.call(workitem, party, false)
+            end
           else
             workitem.transition.transition_static_assignments.each do |static_assignment|
               AddWorkitemAssignment.call(workitem, static_assignment.party, false)

--- a/app/models/wf/case_command/set_workitem_assignments.rb
+++ b/app/models/wf/case_command/set_workitem_assignments.rb
@@ -20,7 +20,7 @@ module Wf::CaseCommand
           callback_parties = workitem.transition.assignment_callback.constantize.new.perform(workitem.id)
           if callback_parties.present?
             callback_parties.each do |party|
-               AddWorkitemAssignment.call(workitem, party, false)
+              AddWorkitemAssignment.call(workitem, party, false)
             end
           else
             workitem.transition.transition_static_assignments.each do |static_assignment|

--- a/app/models/wf/transition.rb
+++ b/app/models/wf/transition.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: wf_transitions

--- a/lib/wf/version.rb
+++ b/lib/wf/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wf
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end

--- a/test/dummy/config/initializers/my_assignment_callback.rb
+++ b/test/dummy/config/initializers/my_assignment_callback.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class MyAssignmentCallback
+  def perform(_workitem_id)
+    Wf::Party.all.sample(2)
+  end
+end
+
+Wf.assignment_callbacks = ["Wf::Callbacks::AssignmentDefault", "MyAssignmentCallback"]

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -186,3 +186,16 @@ proc do
     t1.transition_static_assignments.create!(party: user.party)
   end
 end.call
+
+proc do
+  seq = Wf::Workflow.create(name: "Workflow with AssigmentCallback")
+  s = seq.places.create!(place_type: :start, name: "start")
+  e = seq.places.create!(place_type: :end, name: "end")
+  p = seq.places.create!(place_type: :normal, name: "p")
+  t1 = seq.transitions.create!(name: "t1", assignment_callback: "MyAssignmentCallback")
+  t2 = seq.transitions.create!(name: "t2")
+  arc1 = seq.arcs.create!(direction: :in, transition: t1, place: s)
+  arc2 = seq.arcs.create!(direction: :out, transition: t1, place: p)
+  arc3 = seq.arcs.create!(direction: :in, transition: t2, place: p)
+  arc4 = seq.arcs.create!(direction: :out, transition: t2, place: e)
+end.call


### PR DESCRIPTION
## AssignmentCallback

* argument: `workitem_id`
* return: array of `Wf::Party` instance
* sync exec

## Usage Case

dynamic set assignment for workitem, for example
*  set assignment to first two leader of some department
*  set assignment to pre workitem's holding user's  leader

```ruby
module Wf::Callbacks
  class YourAssignment < ApplicationJob
    queue_as :default

    def perform(workitem_id)
      workitem = Wf::Workitem.find(workitem_id)
      current_transition = workitem.transition
      pre_transition = current_transition.dynamic_assign_by
      return [] if pre_transition.blank?
      pre_workitem = pre_transition.workitems.where(case: workitem.case).order("id desc").first
      return [] if pre_workitem.blank?
      return Array(pre_workitem&.holding_user&.leader&.party)
    end
  end
end
```

then 

```ruby
Wf.assignment_callbacks = ["Wf::Callbacks::AssignmentDefault", "Wf::Callbacks::YourAssignment"]
```

then

![image](https://user-images.githubusercontent.com/63877/75610194-e4f19800-5b49-11ea-8499-de6c9eec31b8.png)


